### PR TITLE
Accept any 20x response on upload as "OK"

### DIFF
--- a/lib/util/ckan-upload-api.js
+++ b/lib/util/ckan-upload-api.js
@@ -15,7 +15,7 @@ const CkanUploadAPI = {
     }
 
     const response = await axios.put(href, body, config)
-    if (response.status !== 201) {
+    if (Math.floor(response.status / 100) !== 2) {
       throw "Uploading the file to storage failed"
     }
 


### PR DESCRIPTION
When using Google Cloud as a backend, HTTP `200` is returned on successful upload. When using Azure, `201` is returned. Both of them should be accepted.